### PR TITLE
Dynamic Filters

### DIFF
--- a/src/basic-dynamic-filter-builder.ts
+++ b/src/basic-dynamic-filter-builder.ts
@@ -1,0 +1,166 @@
+import {
+  Type, ODataProperty, ODataPropertyPath,
+  ODataTypes,
+  IBasicDynamicFilterBuilder,
+  IDynamicCollectionPropFilterBuilder,
+  IDynamicFilterBuilderResult,
+  IDynamicFilterExpressionResult,
+  BasicDynamicBuilderFunc,
+  BasicDynamicBuilderArg,
+  BasicDynamicBuilderArgFunc,
+  TDynamicPropType
+} from './dynamic-types'
+
+
+export class DynamicFilterExpressionResult
+  implements IDynamicFilterExpressionResult {
+  constructor(private stringResult: string) {}
+  getString() {
+    return this.stringResult
+  }
+}
+
+export function buildWithBuilder<T, TBuilder extends BasicDynamicFilterBuilder>(
+  builder: TBuilder,
+  f: BasicDynamicBuilderFunc<TBuilder>
+) {
+  if (!f) {
+    return new DynamicFilterExpressionResult('')
+  }
+  const result = f(builder, builder.prop)
+  const str = builder.getArgString(result)
+  return new DynamicFilterExpressionResult(str)
+}
+
+export class BasicDynamicFilterBuilder implements IBasicDynamicFilterBuilder {
+  protected constructor(protected prefix: string | null = null) {}
+
+  getArgString<
+    TResult extends TDynamicPropType,
+    TBuilder extends BasicDynamicFilterBuilder
+  >(arg: BasicDynamicBuilderArg<TBuilder, TResult>): string {
+    if (typeof arg === 'function') {
+      const func = arg as BasicDynamicBuilderArgFunc<BasicDynamicFilterBuilder, TResult>
+      arg = func(this, this.prop)
+    }
+
+    if(arg instanceof ODataPropertyPath)
+    {
+       return arg.path;
+    }
+    if (arg instanceof DynamicFilterExpressionResult) {
+      return arg.getString()
+    }
+    if (arg instanceof Date) {
+      return arg.toISOString()
+    }
+    if (typeof arg === 'string') {
+      return `'${(arg as string).replace(/'/g, "''")}'`
+    }
+    return JSON.stringify(arg)
+  }
+
+  function<TResult extends TDynamicPropType, TBuilder extends BasicDynamicFilterBuilder>(
+    functionName: string,
+    ...args: BasicDynamicBuilderArg<TBuilder, TDynamicPropType>[]
+  ) {
+    const argsString = args.map(a => this.getArgString(a)).join(', ')
+    return new DynamicFilterExpressionResult(
+      `${functionName}(${argsString})`
+    )
+  }
+
+  binaryOperator<
+    TArg extends TDynamicPropType,
+    TBuilder extends BasicDynamicFilterBuilder
+  >(
+    op: string,
+    left: BasicDynamicBuilderArg<TBuilder, TArg>,
+    right: BasicDynamicBuilderArg<TBuilder, TArg>
+  ): DynamicFilterExpressionResult {
+    const leftStr = this.getArgString(left)
+    const rightStr = this.getArgString(right)
+    return new DynamicFilterExpressionResult(
+      `${leftStr} ${op} ${rightStr}`
+    )
+  }
+
+  protected logicalOperator<
+    TArg extends TDynamicPropType,
+    TBuilder extends BasicDynamicFilterBuilder
+  >(op: string, ...args: BasicDynamicBuilderArg<TBuilder, TArg>[]) {
+    if (!args.length) {
+      return new DynamicFilterExpressionResult(`true`)
+    }
+    const argsString = args.map(a => this.getArgString(a)).join(` ${op} `)
+    return new DynamicFilterExpressionResult(`(${argsString})`)
+  }
+
+  get prop() : ODataPropertyPath {
+    const prefix = this.prefix ? this.prefix : '';
+    return new ODataPropertyPath(prefix);
+  }
+
+  protected collectionProp<TBuilder extends BasicDynamicFilterBuilder>(
+    prop: any,
+    varName: string | null
+  ): IDynamicCollectionPropFilterBuilder<TBuilder> {
+    const polymorphicCtor = this.constructor as any
+    return new DynamicCollectionPropFilterBuilder(prop, polymorphicCtor, varName)
+  }
+
+  protected nestedCondition<TBuilder extends BasicDynamicFilterBuilder>(
+    prop: ODataPropertyPath,
+    condition: BasicDynamicBuilderArg<TBuilder, ODataTypes.Bool>
+  ): DynamicFilterExpressionResult{
+    const polymorphicCtor = this.constructor as any
+    const prefix = prop.path
+    const nestedBuilder: TBuilder = new polymorphicCtor(prefix)
+    return new DynamicFilterExpressionResult(
+      nestedBuilder.getArgString(condition)
+    )
+  }
+}
+
+class DynamicCollectionPropFilterBuilder<TBuilder extends BasicDynamicFilterBuilder>
+  implements IDynamicCollectionPropFilterBuilder<TBuilder> {
+  constructor(
+    private collectionProp: ODataPropertyPath,
+    private builderClass: Type<TBuilder>,
+    private varName: string | null
+  ) {}
+
+  any(condition: BasicDynamicBuilderArgFunc<TBuilder, ODataTypes.Bool> | null = null) {
+    return this.collectionFunc('any', condition)
+  }
+
+  all(condition: BasicDynamicBuilderArgFunc<TBuilder, ODataTypes.Bool>) {
+    return this.collectionFunc('all', condition)
+  }
+
+  private collectionFunc(
+    name: string,
+    condition: BasicDynamicBuilderArgFunc<TBuilder, ODataTypes.Bool> | null
+  ) {
+    const prefix = this.collectionProp.path
+    if (!condition) {
+      return new DynamicFilterExpressionResult(`${prefix}/${name}()`)
+    }
+
+    const varName =
+      this.varName ||
+      'i' +
+        Math.floor((1 + Math.random()) * 0x10000)
+          .toString(16)
+          .substring(1)
+    const builder = new this.builderClass(varName)
+    return new DynamicFilterExpressionResult(
+      `${prefix}/${name}(${varName}: ${builder.getArgString(condition)})`
+    )
+  }
+
+  get count() {
+    const prefix = this.collectionProp;
+    return new DynamicFilterExpressionResult(`${prefix}/$count`)
+  }
+}

--- a/src/basic-dynamic-filter-builder.ts
+++ b/src/basic-dynamic-filter-builder.ts
@@ -1,6 +1,6 @@
 import {
-  Type, ODataProperty, ODataPropertyPath,
-  ODataTypes,
+  Type, 
+  ODataPropertyPath,
   IBasicDynamicFilterBuilder,
   IDynamicCollectionPropFilterBuilder,
   IDynamicFilterBuilderResult,

--- a/src/basic-dynamic-filter-builder.ts
+++ b/src/basic-dynamic-filter-builder.ts
@@ -8,7 +8,7 @@ import {
   BasicDynamicBuilderFunc,
   BasicDynamicBuilderArg,
   BasicDynamicBuilderArgFunc,
-  TDynamicPropType
+  BasicBuilderProp
 } from './dynamic-types'
 
 
@@ -36,11 +36,10 @@ export class BasicDynamicFilterBuilder implements IBasicDynamicFilterBuilder {
   protected constructor(protected prefix: string | null = null) {}
 
   getArgString<
-    TResult extends TDynamicPropType,
     TBuilder extends BasicDynamicFilterBuilder
-  >(arg: BasicDynamicBuilderArg<TBuilder, TResult>): string {
+  >(arg: BasicDynamicBuilderArg<TBuilder>): string {
     if (typeof arg === 'function') {
-      const func = arg as BasicDynamicBuilderArgFunc<BasicDynamicFilterBuilder, TResult>
+      const func = arg as BasicDynamicBuilderArgFunc<BasicDynamicFilterBuilder>
       arg = func(this, this.prop)
     }
 
@@ -60,9 +59,9 @@ export class BasicDynamicFilterBuilder implements IBasicDynamicFilterBuilder {
     return JSON.stringify(arg)
   }
 
-  function<TResult extends TDynamicPropType, TBuilder extends BasicDynamicFilterBuilder>(
+  function<TBuilder extends BasicDynamicFilterBuilder>(
     functionName: string,
-    ...args: BasicDynamicBuilderArg<TBuilder, TDynamicPropType>[]
+    ...args: BasicDynamicBuilderArg<TBuilder>[]
   ) {
     const argsString = args.map(a => this.getArgString(a)).join(', ')
     return new DynamicFilterExpressionResult(
@@ -71,12 +70,11 @@ export class BasicDynamicFilterBuilder implements IBasicDynamicFilterBuilder {
   }
 
   binaryOperator<
-    TArg extends TDynamicPropType,
     TBuilder extends BasicDynamicFilterBuilder
   >(
     op: string,
-    left: BasicDynamicBuilderArg<TBuilder, TArg>,
-    right: BasicDynamicBuilderArg<TBuilder, TArg>
+    left: BasicDynamicBuilderArg<TBuilder>,
+    right: BasicDynamicBuilderArg<TBuilder>
   ): DynamicFilterExpressionResult {
     const leftStr = this.getArgString(left)
     const rightStr = this.getArgString(right)
@@ -86,9 +84,8 @@ export class BasicDynamicFilterBuilder implements IBasicDynamicFilterBuilder {
   }
 
   protected logicalOperator<
-    TArg extends TDynamicPropType,
     TBuilder extends BasicDynamicFilterBuilder
-  >(op: string, ...args: BasicDynamicBuilderArg<TBuilder, TArg>[]) {
+  >(op: string, ...args: BasicDynamicBuilderArg<TBuilder>[]) {
     if (!args.length) {
       return new DynamicFilterExpressionResult(`true`)
     }
@@ -110,8 +107,8 @@ export class BasicDynamicFilterBuilder implements IBasicDynamicFilterBuilder {
   }
 
   protected nestedCondition<TBuilder extends BasicDynamicFilterBuilder>(
-    prop: ODataPropertyPath,
-    condition: BasicDynamicBuilderArg<TBuilder, ODataTypes.Bool>
+    prop: BasicBuilderProp<TBuilder>,
+    condition: BasicDynamicBuilderArg<TBuilder>
   ): DynamicFilterExpressionResult{
     const polymorphicCtor = this.constructor as any
     const prefix = prop.path
@@ -130,17 +127,17 @@ class DynamicCollectionPropFilterBuilder<TBuilder extends BasicDynamicFilterBuil
     private varName: string | null
   ) {}
 
-  any(condition: BasicDynamicBuilderArgFunc<TBuilder, ODataTypes.Bool> | null = null) {
+  any(condition: BasicDynamicBuilderArgFunc<TBuilder> | null = null) {
     return this.collectionFunc('any', condition)
   }
 
-  all(condition: BasicDynamicBuilderArgFunc<TBuilder, ODataTypes.Bool>) {
+  all(condition: BasicDynamicBuilderArgFunc<TBuilder>) {
     return this.collectionFunc('all', condition)
   }
 
   private collectionFunc(
     name: string,
-    condition: BasicDynamicBuilderArgFunc<TBuilder, ODataTypes.Bool> | null
+    condition: BasicDynamicBuilderArgFunc<TBuilder> | null
   ) {
     const prefix = this.collectionProp.path
     if (!condition) {

--- a/src/dynamic-types.ts
+++ b/src/dynamic-types.ts
@@ -1,0 +1,78 @@
+export interface Type<T> {
+  new (...args: any[]): T;
+}
+
+export class ODataEntityType
+{
+    name: string = '';
+    properties: ODataProperty[] = new Array<ODataProperty>();
+}
+
+export class ODataPropertyPath
+{
+   constructor(public path:string) {
+   }
+
+   child(subPath: string) : ODataPropertyPath
+   {
+     return new ODataPropertyPath(`${this.path}/${subPath}`);
+   }
+}
+
+export class ODataProperty
+{
+    name: string = '';
+    type: ODataTypes = 0;
+    isNullable: boolean = false;
+}
+
+export enum ODataTypes{
+  Number,
+  String,
+  Date,
+  Bool,
+}
+
+export type ODataDynamicTPrimitive = ODataTypes.Number | ODataTypes.String | ODataTypes.Date | ODataTypes.Bool;
+export type TDynamicPropType = ODataDynamicTPrimitive;
+
+//export type BasicBuilderProp<TBuilder extends IBasicFilterBuilder, TResult> = any;
+
+export type BasicDynamicBuilderArg<TBuilder extends IBasicDynamicFilterBuilder, TResult extends TDynamicPropType> =
+  BasicDynamicBuilderArgFunc<TBuilder, TResult> |
+  IDynamicFilterExpressionResult |
+  ODataPropertyPath |
+  TResult;
+
+export type BasicDynamicBuilderArgFunc<TBuilder extends IBasicDynamicFilterBuilder, TResult extends TDynamicPropType> =
+  (arg: TBuilder, props: any)=> BasicDynamicBuilderArg<TBuilder, TResult>;
+
+export type BasicDynamicBuilderFunc<TBuilder extends IBasicDynamicFilterBuilder> =
+  BasicDynamicBuilderArgFunc<TBuilder, ODataTypes.Bool>;
+
+export interface IDynamicCollectionPropFilterBuilder<TBuilder extends IBasicDynamicFilterBuilder> {
+  count: IDynamicFilterExpressionResult;
+  any(condition?: BasicDynamicBuilderArgFunc<TBuilder, ODataTypes.Bool>): IDynamicFilterBuilderResult;
+  all(condition: BasicDynamicBuilderArgFunc<TBuilder, ODataTypes.Bool>): IDynamicFilterBuilderResult;
+}
+
+export interface IBasicDynamicFilterBuilder {
+  prop: ODataPropertyPath;
+  // collection: <I, TBuilder extends IBasicFilterBuilder<I>>(prop: ObjPathProxy<T, Array<I>>)=> ICollectionPropFilterBuilder<I, TBuilder>;
+  binaryOperator<TArg extends TDynamicPropType>(
+    op: string,
+    left: BasicDynamicBuilderArg<IBasicDynamicFilterBuilder,TArg>,
+    right: BasicDynamicBuilderArg<IBasicDynamicFilterBuilder,TArg>
+  ): IDynamicFilterExpressionResult;
+  getArgString<TResult extends TDynamicPropType>(
+    arg: BasicDynamicBuilderArg<IBasicDynamicFilterBuilder, TResult>
+  ): string
+}
+
+export interface IDynamicFilterExpressionResult {
+  getString(): string;
+}
+
+export interface IDynamicFilterBuilderResult extends IDynamicFilterExpressionResult { }
+
+

--- a/src/dynamic-types.ts
+++ b/src/dynamic-types.ts
@@ -2,11 +2,6 @@ export interface Type<T> {
   new (...args: any[]): T;
 }
 
-export class ODataEntityType
-{
-    name: string = '';
-    properties: ODataProperty[] = new Array<ODataProperty>();
-}
 
 export class ODataPropertyPath
 {
@@ -17,20 +12,6 @@ export class ODataPropertyPath
    {
      return new ODataPropertyPath(`${this.path}/${subPath}`);
    }
-}
-
-export class ODataProperty
-{
-    name: string = '';
-    type: ODataTypes = 0;
-    isNullable: boolean = false;
-}
-
-export enum ODataTypes{
-  Number,
-  String,
-  Date,
-  Bool,
 }
 
 

--- a/src/dynamic-types.ts
+++ b/src/dynamic-types.ts
@@ -33,39 +33,37 @@ export enum ODataTypes{
   Bool,
 }
 
-export type ODataDynamicTPrimitive = ODataTypes.Number | ODataTypes.String | ODataTypes.Date | ODataTypes.Bool;
-export type TDynamicPropType = ODataDynamicTPrimitive;
 
-//export type BasicBuilderProp<TBuilder extends IBasicFilterBuilder, TResult> = any;
+export type BasicBuilderProp<TBuilder extends IBasicDynamicFilterBuilder> = ODataPropertyPath;
 
-export type BasicDynamicBuilderArg<TBuilder extends IBasicDynamicFilterBuilder, TResult extends TDynamicPropType> =
-  BasicDynamicBuilderArgFunc<TBuilder, TResult> |
+export type BasicDynamicBuilderArg<TBuilder extends IBasicDynamicFilterBuilder> =
+  BasicDynamicBuilderArgFunc<TBuilder> |
   IDynamicFilterExpressionResult |
-  ODataPropertyPath |
-  TResult;
+  BasicBuilderProp<TBuilder> |
+  String | Number | Boolean | Date;
 
-export type BasicDynamicBuilderArgFunc<TBuilder extends IBasicDynamicFilterBuilder, TResult extends TDynamicPropType> =
-  (arg: TBuilder, props: any)=> BasicDynamicBuilderArg<TBuilder, TResult>;
+export type BasicDynamicBuilderArgFunc<TBuilder extends IBasicDynamicFilterBuilder> =
+  (arg: TBuilder, props: any)=> BasicDynamicBuilderArg<TBuilder>;
 
 export type BasicDynamicBuilderFunc<TBuilder extends IBasicDynamicFilterBuilder> =
-  BasicDynamicBuilderArgFunc<TBuilder, ODataTypes.Bool>;
+  BasicDynamicBuilderArgFunc<TBuilder>;
 
 export interface IDynamicCollectionPropFilterBuilder<TBuilder extends IBasicDynamicFilterBuilder> {
   count: IDynamicFilterExpressionResult;
-  any(condition?: BasicDynamicBuilderArgFunc<TBuilder, ODataTypes.Bool>): IDynamicFilterBuilderResult;
-  all(condition: BasicDynamicBuilderArgFunc<TBuilder, ODataTypes.Bool>): IDynamicFilterBuilderResult;
+  any(condition?: BasicDynamicBuilderArgFunc<TBuilder>): IDynamicFilterBuilderResult;
+  all(condition: BasicDynamicBuilderArgFunc<TBuilder>): IDynamicFilterBuilderResult;
 }
 
 export interface IBasicDynamicFilterBuilder {
-  prop: ODataPropertyPath;
+  prop: any;
   // collection: <I, TBuilder extends IBasicFilterBuilder<I>>(prop: ObjPathProxy<T, Array<I>>)=> ICollectionPropFilterBuilder<I, TBuilder>;
-  binaryOperator<TArg extends TDynamicPropType>(
+  binaryOperator(
     op: string,
-    left: BasicDynamicBuilderArg<IBasicDynamicFilterBuilder,TArg>,
-    right: BasicDynamicBuilderArg<IBasicDynamicFilterBuilder,TArg>
+    left: BasicDynamicBuilderArg<IBasicDynamicFilterBuilder>,
+    right: BasicDynamicBuilderArg<IBasicDynamicFilterBuilder>
   ): IDynamicFilterExpressionResult;
-  getArgString<TResult extends TDynamicPropType>(
-    arg: BasicDynamicBuilderArg<IBasicDynamicFilterBuilder, TResult>
+  getArgString(
+    arg: BasicDynamicBuilderArg<IBasicDynamicFilterBuilder>
   ): string
 }
 

--- a/src/odata-dynamic-filter-builder.ts
+++ b/src/odata-dynamic-filter-builder.ts
@@ -1,0 +1,103 @@
+import {
+  IBasicDynamicFilterBuilder, IDynamicCollectionPropFilterBuilder,
+  IDynamicFilterBuilderResult, IDynamicFilterExpressionResult,
+  BasicDynamicBuilderFunc, BasicDynamicBuilderArg, BasicDynamicBuilderArgFunc,
+  TDynamicPropType,
+  ODataPropertyPath,
+  ODataTypes
+} from './dynamic-types';
+import { buildWithBuilder, BasicDynamicFilterBuilder, DynamicFilterExpressionResult } from './basic-dynamic-filter-builder';
+
+export type BuilderFunc<T> = BasicDynamicBuilderFunc<ODataDynamicFilterBuilder>;
+
+export type BuilderArg<TResult extends TDynamicPropType> = BasicDynamicBuilderArg<ODataDynamicFilterBuilder, TResult>;
+export type BoolArg = BuilderArg<ODataTypes.Bool>;
+export type NumArg = BuilderArg<ODataTypes.Number>;
+export type StringArg = BuilderArg<ODataTypes.String>;
+export type DateArg = BuilderArg<ODataTypes.Date>;
+
+export type BoolResult = IDynamicFilterExpressionResult;
+export type StringResult = IDynamicFilterExpressionResult;
+export type NumResult = IDynamicFilterExpressionResult;
+export type DateResult = IDynamicFilterExpressionResult;
+
+export type Operator<T, TArg extends TDynamicPropType> =
+  (l: BuilderArg<TArg>, r: BuilderArg<TArg>) =>  BoolResult;
+
+export type StringFunc = (l: StringArg) => StringResult;
+export type StringFunc2 = (l: StringArg, r: StringArg) => StringResult;
+export type StringFunc3 = (one: StringArg, two: StringArg, three: StringArg) => StringResult;
+export type StringBoolFunc = (l: StringArg, r: StringArg) => BoolResult;
+export type DateFunc = (d: DateArg) => DateResult;
+export type DatePartFunc = (d: DateArg) => NumResult;
+export type NumFunc = (d: NumArg) => NumResult;
+
+// implemets operators and functions from https://msdn.microsoft.com/en-us/library/hh169248(v=nav.90).aspx
+export class ODataDynamicFilterBuilder extends BasicDynamicFilterBuilder {
+  static build(f: BasicDynamicBuilderFunc<ODataDynamicFilterBuilder>): IDynamicFilterBuilderResult {
+    return buildWithBuilder(new ODataDynamicFilterBuilder(), f);
+  }
+
+  collection = (
+    prop: ODataPropertyPath,
+    varName: string|null = null
+  ): IDynamicCollectionPropFilterBuilder<ODataDynamicFilterBuilder> =>
+    this.collectionProp(prop, varName);
+
+  nested = (
+    prop: ODataPropertyPath,
+    condition: BasicDynamicBuilderArg<ODataDynamicFilterBuilder, ODataTypes.Bool>
+  ): DynamicFilterExpressionResult => this.nestedCondition<ODataDynamicFilterBuilder>(prop, condition);
+
+  // logical
+  and = (...args: BoolArg[]) => this.logicalOperator('and', ...args);
+  or = (...args: BoolArg[]) => this.logicalOperator('or', ...args);
+  not = (arg: BoolArg): BoolResult => this.function('not', arg);
+
+  // number operators
+  lt = <TArg extends TDynamicPropType>(l: BuilderArg<TArg>, r: BuilderArg<TArg>) =>
+    this.binaryOperator('lt', l, r); // less than
+  gt = <TArg extends TDynamicPropType>(l: BuilderArg<TArg>, r: BuilderArg<TArg>) =>
+    this.binaryOperator('gt', l, r); // greater than
+  le = <TArg extends TDynamicPropType>(l: BuilderArg<TArg>, r: BuilderArg<TArg>) =>
+    this.binaryOperator('le', l, r); // less than or equals
+  ge = <TArg extends TDynamicPropType>(l: BuilderArg<TArg>, r: BuilderArg<TArg>) =>
+    this.binaryOperator('ge', l, r); // greater than or equals
+  eq = <TArg extends TDynamicPropType>(l: BuilderArg<TArg>, r: BuilderArg<TArg>) =>
+    this.binaryOperator('eq', l, r); // equals
+  ne = <TArg extends TDynamicPropType>(l: BuilderArg<TArg>, r: BuilderArg<TArg>) =>
+    this.binaryOperator('ne', l, r); // not equal
+
+  // string functions
+  endswith: StringBoolFunc =                        (left, right) => this.function('endswith', left, right);
+  startswith: StringBoolFunc =                      (left, right) => this.function('startswith', left, right);
+  substringof: StringBoolFunc =                     (left, right) => this.function('substringof', left, right);
+  length =                         (str: StringArg): NumResult => this.function('length', str);
+  indexof =         (l: StringArg, r: StringArg): NumResult => this.function('indexof', l, r);
+  replace: StringFunc3 =                       (str, remove, add) => this.function('replace', str, remove, add);
+  substring = (str: StringArg, index: NumArg): StringResult => this.function('substring', str, index);
+  tolower: StringFunc =                                     (str) => this.function('tolower', str);
+  toupper: StringFunc =                                     (str) => this.function('toupper', str);
+  trim: StringFunc =                                        (str) => this.function('trim', str);
+  concat: StringFunc2 =                             (left, right) => this.function('concat', left, right);
+  contains =        (l: StringArg, r: StringArg): NumResult => this.function('contains', l, r);
+
+  // date functions
+  day: DatePartFunc =                d => this.function('day', d);
+  month: DatePartFunc =              d => this.function('month', d);
+  year: DatePartFunc =               d => this.function('year', d);
+  hour: DatePartFunc =               d => this.function('hour', d);
+  minute: DatePartFunc =             d => this.function('minute', d);
+  second: DatePartFunc =             d => this.function('second', d);
+  date: DateFunc =                   d => this.function('date', d);
+  time: DateFunc =                   d => this.function('time', d);
+  totaloffsetminutes: DatePartFunc = d => this.function('totaloffsetminutes', d);
+  now: () => DateResult =           () => this.function('now');
+  mindatetime: () => DateResult =   () => this.function('mindatetime');
+  maxdatetime: () => DateResult =   () => this.function('maxdatetime');
+
+  // number functions
+  round: NumFunc = n => this.function('round', n);
+  floor: NumFunc = n => this.function('floor', n);
+  ceiling: NumFunc = n => this.function('ceiling', n);
+}

--- a/src/odata-dynamic-filter-builder.ts
+++ b/src/odata-dynamic-filter-builder.ts
@@ -3,7 +3,6 @@ import {
   IDynamicFilterBuilderResult, IDynamicFilterExpressionResult,
   BasicDynamicBuilderFunc, BasicDynamicBuilderArg, BasicDynamicBuilderArgFunc,
   ODataPropertyPath,
-  ODataTypes
 } from './dynamic-types';
 import { buildWithBuilder, BasicDynamicFilterBuilder, DynamicFilterExpressionResult } from './basic-dynamic-filter-builder';
 

--- a/src/odata-dynamic-filter-builder.ts
+++ b/src/odata-dynamic-filter-builder.ts
@@ -2,7 +2,6 @@ import {
   IBasicDynamicFilterBuilder, IDynamicCollectionPropFilterBuilder,
   IDynamicFilterBuilderResult, IDynamicFilterExpressionResult,
   BasicDynamicBuilderFunc, BasicDynamicBuilderArg, BasicDynamicBuilderArgFunc,
-  TDynamicPropType,
   ODataPropertyPath,
   ODataTypes
 } from './dynamic-types';
@@ -10,19 +9,19 @@ import { buildWithBuilder, BasicDynamicFilterBuilder, DynamicFilterExpressionRes
 
 export type BuilderFunc<T> = BasicDynamicBuilderFunc<ODataDynamicFilterBuilder>;
 
-export type BuilderArg<TResult extends TDynamicPropType> = BasicDynamicBuilderArg<ODataDynamicFilterBuilder, TResult>;
-export type BoolArg = BuilderArg<ODataTypes.Bool>;
-export type NumArg = BuilderArg<ODataTypes.Number>;
-export type StringArg = BuilderArg<ODataTypes.String>;
-export type DateArg = BuilderArg<ODataTypes.Date>;
+export type BuilderArg = BasicDynamicBuilderArg<ODataDynamicFilterBuilder>;
+export type BoolArg = BuilderArg;
+export type NumArg = BuilderArg;
+export type StringArg = BuilderArg;
+export type DateArg = BuilderArg;
 
 export type BoolResult = IDynamicFilterExpressionResult;
 export type StringResult = IDynamicFilterExpressionResult;
 export type NumResult = IDynamicFilterExpressionResult;
 export type DateResult = IDynamicFilterExpressionResult;
 
-export type Operator<T, TArg extends TDynamicPropType> =
-  (l: BuilderArg<TArg>, r: BuilderArg<TArg>) =>  BoolResult;
+export type Operator<T> =
+  (l: BuilderArg, r: BuilderArg) =>  BoolResult;
 
 export type StringFunc = (l: StringArg) => StringResult;
 export type StringFunc2 = (l: StringArg, r: StringArg) => StringResult;
@@ -46,7 +45,7 @@ export class ODataDynamicFilterBuilder extends BasicDynamicFilterBuilder {
 
   nested = (
     prop: ODataPropertyPath,
-    condition: BasicDynamicBuilderArg<ODataDynamicFilterBuilder, ODataTypes.Bool>
+    condition: BasicDynamicBuilderArg<ODataDynamicFilterBuilder>
   ): DynamicFilterExpressionResult => this.nestedCondition<ODataDynamicFilterBuilder>(prop, condition);
 
   // logical
@@ -55,17 +54,17 @@ export class ODataDynamicFilterBuilder extends BasicDynamicFilterBuilder {
   not = (arg: BoolArg): BoolResult => this.function('not', arg);
 
   // number operators
-  lt = <TArg extends TDynamicPropType>(l: BuilderArg<TArg>, r: BuilderArg<TArg>) =>
+  lt = (l: BuilderArg, r: BuilderArg) =>
     this.binaryOperator('lt', l, r); // less than
-  gt = <TArg extends TDynamicPropType>(l: BuilderArg<TArg>, r: BuilderArg<TArg>) =>
+  gt = (l: BuilderArg, r: BuilderArg) =>
     this.binaryOperator('gt', l, r); // greater than
-  le = <TArg extends TDynamicPropType>(l: BuilderArg<TArg>, r: BuilderArg<TArg>) =>
+  le = (l: BuilderArg, r: BuilderArg) =>
     this.binaryOperator('le', l, r); // less than or equals
-  ge = <TArg extends TDynamicPropType>(l: BuilderArg<TArg>, r: BuilderArg<TArg>) =>
+  ge = (l: BuilderArg, r: BuilderArg) =>
     this.binaryOperator('ge', l, r); // greater than or equals
-  eq = <TArg extends TDynamicPropType>(l: BuilderArg<TArg>, r: BuilderArg<TArg>) =>
+  eq = (l: BuilderArg, r: BuilderArg) =>
     this.binaryOperator('eq', l, r); // equals
-  ne = <TArg extends TDynamicPropType>(l: BuilderArg<TArg>, r: BuilderArg<TArg>) =>
+  ne = (l: BuilderArg, r: BuilderArg) =>
     this.binaryOperator('ne', l, r); // not equal
 
   // string functions

--- a/src/ts-odata-dynamic-filter.ts
+++ b/src/ts-odata-dynamic-filter.ts
@@ -1,0 +1,6 @@
+// Import here Polyfills if needed. Recommended core-js (npm i -D core-js)
+  // import "core-js/fn/array.find"
+  // ...
+export * from './dynamic-types';
+export * from './basic-dynamic-filter-builder';
+export * from './odata-dynamic-filter-builder';


### PR DESCRIPTION
Since you so kindly saved me the trouble of making a nice architecture for the builder.

I've created a dynamic builder from your library.
Sorry,  I tested this manually 

Example working:
```
let filterBuilder = ODataDynamicFilterBuilder.build(builder => 
            builder.or(
            builder.collection(messagesPath, "m").any(
                (mb, mp) =>
                { 
                    console.log(mp);
                    return mb.nested(mp.child("Conversation"), (cb, cp)=> {
                        console.log(cp);
                        return cb.eq(cp.child("Id"), 1005)
                    });
                }),
            builder.or(        
                builder.or(
                    builder.eq(new ODataPropertyPath("Id"), id),
                    builder.contains(new ODataPropertyPath("LastName"), "ouch")
                ),
                builder.collection(new ODataPropertyPath("Messages"), "m").any(m => m.eq(new ODataPropertyPath("Id"), 5))
            )
        )
        );
        let filterString = filterBuilder.getString();
```

that will generate:

(Messages/any(m: m/Conversation/Id eq 1005) or ((Id eq 2 or contains(LastName, 'ouch')) or Messages/any(m: Id eq 5)))
